### PR TITLE
ci(github-actions): Enable GitHub Pages configuration

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- Add enablement flag to configure-pages action
- Set enablement to true for explicit Pages activation
- Ensures GitHub Pages is properly configured during deployment workflow