### PR TITLE
ci(cognito): Add Cognito logout URI environment variable

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,6 +39,7 @@ jobs:
           VITE_COGNITO_CLIENT_ID: ${{ secrets.VITE_COGNITO_CLIENT_ID }}
           VITE_COGNITO_DOMAIN: ${{ secrets.VITE_COGNITO_DOMAIN }}
           VITE_COGNITO_REDIRECT_URI: ${{ secrets.VITE_COGNITO_REDIRECT_URI }}
+          VITE_COGNITO_LOGOUT_URI: https://a-nkt.github.io/kakeibo/login
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
 
       - name: Setup Pages

--- a/src/site/src/config/cognito.ts
+++ b/src/site/src/config/cognito.ts
@@ -22,7 +22,7 @@ export const getGoogleLoginUrl = () => {
 
 export const getLogoutUrl = () => {
   const { domain, clientId } = cognitoConfig
-  const logoutRedirectUri = window.location.origin + '/login'
+  const logoutRedirectUri = import.meta.env.VITE_COGNITO_LOGOUT_URI || window.location.origin + import.meta.env.BASE_URL + 'login'
   const params = new URLSearchParams({
     client_id: clientId,
     logout_uri: logoutRedirectUri,


### PR DESCRIPTION
- Add VITE_COGNITO_LOGOUT_URI environment variable to deploy workflow
- Update logout URL configuration to use environment variable with fallback
- Set logout redirect URI to GitHub Pages application URL for production
- Improve logout flow by centralizing URI configuration in environment variables