### PR TITLE
refactor(api): Rename item_id field to id for consistency

### DIFF
--- a/src/api/site/src/app/lambda_function.py
+++ b/src/api/site/src/app/lambda_function.py
@@ -68,7 +68,7 @@ def post_item() -> Response[str]:
         logger.info('POST request received', extra={'request_body': body})
 
         # バリデーション
-        required_fields = ['customer_id', 'item_id', 'price']
+        required_fields = ['customer_id', 'id', 'price']
         for field in required_fields:
             if field not in body:
                 logger.warning('Missing required field', extra={'field': field})
@@ -78,8 +78,8 @@ def post_item() -> Response[str]:
         now = int(datetime.utcnow().timestamp())
         item = {
             'customer_id': body['customer_id'],
-            'id': str(uuid.uuid4()),
-            'item_id': body['item_id'],
+            'item_id': str(uuid.uuid4()),
+            'id': body['id'],
             'price': body['price'],
             'created': now,
             'updated': now,

--- a/src/site/src/utils/api.ts
+++ b/src/site/src/utils/api.ts
@@ -14,7 +14,7 @@ export async function registItem({ customerId, itemId, price }: RegistItemParams
     },
     body: JSON.stringify({
       customer_id: customerId,
-      item_id: itemId,
+      id: itemId,
       price,
     }),
   })

--- a/src/site/src/views/DashboardView.vue
+++ b/src/site/src/views/DashboardView.vue
@@ -44,9 +44,9 @@ const tableColumns = [
 // itemsをテーブル表示用に変換
 const tableRows = computed(() => {
   return itemsStore.items.map(item => {
-    const product = products.find(p => p.id === item.item_id)
+    const product = products.find(p => p.id === item.id)
     return {
-      item_name: product?.name || item.item_id,
+      item_name: product?.name || item.id,
       price: item.price,
       created_date: new Date(item.created * 1000).toLocaleDateString('ja-JP'),
     }


### PR DESCRIPTION
- Rename item_id to id in Lambda function validation and item creation logic
- Update API request payload to use id instead of item_id field name
- Update DashboardView to reference item.id instead of item.item_id
- Align field naming convention across backend API and frontend client codels